### PR TITLE
ScrollToTop y estilos menores en Card

### DIFF
--- a/juira/src/App.js
+++ b/juira/src/App.js
@@ -10,6 +10,7 @@ import Footer from './components/Footer/Footer';
 import NavBar from './components/Navbar/Navbar'
 import ShoppingCart from './components/ShoppingCart/ShoppingCart';
 
+import ScrollToTop from './components/ScrollToTop'
 
 
 function App() {
@@ -20,6 +21,7 @@ function App() {
     <div className="App">
     <BrowserRouter >
       {pathname !== '/' && <NavBar/>}
+      <ScrollToTop />
     <Switch>
       <Route exact path={'/'} component={Landing} />
       <Route exact path={'/juira'} component={Home} />

--- a/juira/src/components/Card/Card.jsx
+++ b/juira/src/components/Card/Card.jsx
@@ -15,8 +15,8 @@ export default function Card(props) {
                         className={styles.card__img}
                         alt="Card" />
                     <div className={styles.card__content}>
+                        <p className={styles.card__price}>{"$ " + props.price.toLocaleString('de-DE')}</p>
                         <h2 className={styles.card__title}>{props.name}</h2>
-                        <p className={styles.card__price}>{"$ " + props.price.toLocaleString()}</p>
                         <p className={styles.card__description}></p>
                     </div>
                 </Link>

--- a/juira/src/components/Card/Card.module.css
+++ b/juira/src/components/Card/Card.module.css
@@ -41,10 +41,26 @@
     line-height: 1.1;
     color: var(--primaryColor);
 }
+@media (max-width: 45em) {
+    .card__title{
+        font-size: 1rem;
+    }
+}
 
 .card__price {
     font-size: 1.75rem;
 }
+@media (max-width: 45em) {
+    .card__price {
+        font-size: 1.3rem;
+    }
+}
+@media (max-width: 35em){
+    .card__price {
+        font-size: 1rem;
+    }
+}
+
 
 .card__img {
     width: 100%;
@@ -68,3 +84,14 @@
 .cardLink {
     text-decoration: none;
 }
+
+a {
+    text-decoration: none;
+    color: gray;
+  }
+  
+  a:visited {
+    text-decoration: none;
+    color: gray;
+  }
+  

--- a/juira/src/components/DetailProduct/Detail.jsx
+++ b/juira/src/components/DetailProduct/Detail.jsx
@@ -68,7 +68,7 @@ export default function Detail() {
     height: 1,
     p: 5,
 }}
-
+    style={{ marginTop: "0" }}
     >
 
     <Paper

--- a/juira/src/components/ScrollToTop.jsx
+++ b/juira/src/components/ScrollToTop.jsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { withRouter } from 'react-router-dom';
+
+function ScrollToTop({ history }) {
+  useEffect(() => {
+    const unlisten = history.listen(() => {
+      window.scrollTo(0, 0);
+    });
+    return () => {
+      unlisten();
+    }
+  }/* , [] */);
+
+  return (null);
+}
+
+export default withRouter(ScrollToTop);
+/* https://stackoverflow.com/questions/36904185/react-router-scroll-to-top-on-every-transition */


### PR DESCRIPTION
  - ✔ Al clickear una Card, ademas de llevar al Detail, scrollear pagina.
  - ✔ Arreglar estilos Card color del precio, transformar $1000 a $1.000 con toLocaleString --> 'de-DE' y agregar  media queries para reducir font-size en pantallas mas chicas.
  - ✔ Card: mover Price arriba de Name
  - ✔ Detail espacio en blanco entre Navbar y contenido del detalle
		style={{ marginTop: "0" }}