### PR TITLE
Cambiar la etiqueta <a> por <link>

### DIFF
--- a/juira/src/components/Landing/Landing.jsx
+++ b/juira/src/components/Landing/Landing.jsx
@@ -15,7 +15,7 @@ export default function Landing() {
                         className={styles.logo}></img>
                 </div>
                 <br />
-                <a href="/juira" className={styles.btnEntrar}>Ingresar</a>
+                <Link to="/juira" className={styles.btnEntrar}>Ingresar</Link>
                 {/* <Link to="/juira" className={styles.btnEntrar} onClick={()=>{history.push('/juira')}}>Ingresar</Link> */}
             </div>
             <div className={styles.imgWrapper}>


### PR DESCRIPTION
El boton del landing tenia una etiqueta '<a href....' en lugar de un '<link to....'